### PR TITLE
Elixir 1.4 compatible installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To add it to a mix project, just add a line like this in your deps function in m
 
 ```elixir
 defp deps do
-  [{:dialyxir, "~> 0.4", only: [:dev]}]
+  [{:dialyxir, "~> 0.4", only: [:dev], runtime: false}]
 end
 ```
 


### PR DESCRIPTION
Elixir 1.4 [starts all dependencies](https://github.com/elixir-lang/elixir/blob/v1.4/CHANGELOG.md#application-inference) by default. In our case we don't need the application started before the application. When tested with elixir 1.3.4, this change seems to have no effect so it is backward compatible.